### PR TITLE
[hy_feat/#7] 다크모드 스타일 적용

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -23,6 +23,7 @@
     {
       "matches": ["<all_urls>"],
       "js": ["content.js"],
+      "css": ["content.css"],
       "run_at": "document_end"
     }
   ],

--- a/src/content/content.css
+++ b/src/content/content.css
@@ -1,0 +1,73 @@
+/* 각 사이트별 댓글 텍스트 영역을 미리 숨깁니다 */
+#content-text, /* 유튜브 */
+.u_cbox_contents, /* 네이버 뉴스 */
+ul li span._ap3a[dir="auto"] /* 인스타그램 */ {
+  display: none !important;
+}
+
+/* 로딩 표시 */
+.know-comment-ai-loading { 
+  color: #888; 
+  font-style: italic; 
+  font-size: 14px; 
+}
+
+/* 토글 스위치 스타일 */
+.toggle-switch {
+  display: inline-flex;
+  align-items: center;
+  width: 50px;
+  height: 22px;
+  background-color: #ccc;
+  border-radius: 11px;
+  padding: 2px;
+  box-sizing: border-box;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  margin-left: 12px;
+  vertical-align: middle;
+  user-select: none;
+}
+
+/* 활성화 상태 */
+.toggle-switch.active {
+  background-color: #BFD2FF; /* 활성 상태 색상 */
+  flex-direction: row-reverse; /* 내부 아이템 순서 뒤집기 */
+}
+
+.toggle-label-inside {
+  font-size: 11px;
+  color: white;
+  text-align: center;
+  flex-grow: 1; /* 남는 공간 채우기 */
+  user-select: none;
+  font-weight: normal;
+}
+
+.toggle-circle {
+  width: 18px;
+  height: 18px;
+  background-color: white;
+  border-radius: 50%;
+  flex-shrink: 0; /* 원 크기 유지 */
+  transition: transform 0.1s ease-in-out;
+}
+
+/* 🌙 다크 모드 대응 */
+@media (prefers-color-scheme: dark) {
+  .toggle-switch {
+    background-color: #606081;
+  }
+
+  .toggle-switch.active {
+    background-color: #7A9CD0;
+  }
+
+  .toggle-label-inside {
+    color: #f1f1f1;
+  }
+
+  .know-comment-ai-loading {
+    color: #bbb;
+  }
+}

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -5,9 +5,10 @@ class ContentScript {
   constructor() {
     this.commentScraper = CommentScraper.getInstance();
 
-    this.commentQueue = []; // 댓글 대기열 생성
-    this.batchTimer = null; // 댓글 타이머 생성
+    this.commentQueue = [];
+    this.batchTimer = null;
     this.isProcessing = false;
+
     this.injectGlobalStyles();
 
     this.commentScraper.setOnCommentFound((comment) => this.addCommentToQueue(comment));
@@ -17,62 +18,17 @@ class ContentScript {
   }
 
   injectGlobalStyles() {
+    // 기존에 추가된 스타일이 있으면 중복 방지
     if (document.getElementById('know-comment-ai-styles')) return;
 
-    const style = document.createElement('style');
-    style.id = 'know-comment-ai-styles';
-    style.innerHTML = `
-    /* 각 사이트별 댓글 텍스트 영역을 미리 숨깁니다 */
-    #content-text, /* 유튜브 */
-    .u_cbox_contents, /* 네이버 뉴스 (이 부분을 추가) */
-    span._ap3a[dir="auto"] /* 인스타그램 */ {
-      display: none !important;
-    }
-
-    .know-comment-ai-loading { 
-      color: #888; 
-      font-style: italic; 
-      font-size: 14px; 
-    }
-    /* 신규 토글 스위치 스타일 */
-      .toggle-switch {
-        display: inline-flex;
-        align-items: center;
-        width: 50px;
-        height: 22px;
-        background-color: #ccc;
-        border-radius: 11px;
-        padding: 2px;
-        box-sizing: border-box;
-        cursor: pointer;
-        transition: all 0.2s ease-in-out;
-        margin-left: 12px;
-        vertical-align: middle;
-        user-select: none;
-      }
-      .toggle-switch.active {
-        background-color: #BFD2FF; /* 활성 상태 색상 */
-        flex-direction: row-reverse; /* 내부 아이템 순서 뒤집기 */
-      }
-      .toggle-label-inside {
-        font-size: 11px;
-        color: white;
-        text-align: center;
-        flex-grow: 1; /* 남는 공간 채우기 */
-        user-select: none;
-        font-weight: normal;
-      }
-      .toggle-circle {
-        width: 18px;
-        height: 18px;
-        background-color: white;
-        border-radius: 50%;
-        flex-shrink: 0; /* 원 크기 유지 */
-        transition: transform 0.2s ease-in-out;
-      }
-    `;
-    document.head.appendChild(style);
-    console.log('KnowCommentAI: 스타일 규칙 추가');
+    const link = document.createElement('link');
+    link.id = 'know-comment-ai-styles';
+    link.rel = 'stylesheet';
+    link.type = 'text/css';
+    // content.css 파일을 로드
+    link.href = chrome.runtime.getURL('content.css');
+    document.head.appendChild(link);
+    console.log('KnowCommentAI: 외부 CSS 파일 로드 완료');
   }
 
   setupMessageListener() {
@@ -97,9 +53,9 @@ class ContentScript {
     }, 1000);
   }
 
-addCommentToQueue(comment) {
-const commentBox = comment.element.closest('.u_cbox_comment_box, ._a9zr, #main');
-    if (!commentBox || commentBox.dataset.knowCommentProcessed)return;
+  addCommentToQueue(comment) {
+    const commentBox = comment.element.closest('.u_cbox_comment_box, ._a9zr, #main');
+    if (!commentBox || commentBox.dataset.knowCommentProcessed) return;
 
     commentBox.dataset.knowCommentProcessed = 'true';
     this.commentQueue.push(comment);
@@ -107,37 +63,31 @@ const commentBox = comment.element.closest('.u_cbox_comment_box, ._a9zr, #main')
     this.batchTimer = setTimeout(() => this.startBatchProcessing(), 500);
   }
 
-// API 비어있을 때만 실행
-startBatchProcessing() {
-  if (this.isProcessing) {
-    console.log('이미 다른 묶음을 처리 중입니다. 잠시 대기합니다.');
-    return;
-  }
-  this.processBatches();
-}
-  
-// 원본 댓글 5개씩 병렬 처리
-async processBatches() {
-  this.isProcessing = true;
-
-  if (this.commentQueue.length === 0) {
-    this.isProcessing = false;
-    return;
+  startBatchProcessing() {
+    if (this.isProcessing) {
+      console.log('이미 다른 묶음을 처리 중입니다. 잠시 대기합니다.');
+      return;
+    }
+    this.processBatches();
   }
 
-    // 탐지된 댓글이 없을 때까지 반복
+  async processBatches() {
+    this.isProcessing = true;
+
+    if (this.commentQueue.length === 0) {
+      this.isProcessing = false;
+      return;
+    }
+
     const chunk = this.commentQueue.splice(0, 5);
 
-    // 로딩 UI 표시
     chunk.forEach(comment => {
-      const textElement = comment.element.querySelector('#content-text, .u_cbox_contents, span._ap3a[dir="auto"]');
+      const textElement = comment.element.querySelector('#content-text, .u_cbox_contents, ._a9zr span._ap3a[dir="auto"]');
       if (textElement) {
         comment.textElement = textElement;
         const loadingElement = document.createElement('div');
         loadingElement.className = 'know-comment-ai-loading';
         loadingElement.textContent = '댓글 분석 중... 🤖';
-        
-        // CSS로 숨겨진 textElement 옆에 loadingElement를 삽입
         textElement.parentNode.insertBefore(loadingElement, textElement);
         comment.loadingElement = loadingElement;
       }
@@ -148,8 +98,7 @@ async processBatches() {
     const apiResults = await Promise.all(promises);
 
     console.log(`📥 ${chunk.length}개 묶음의 응답을 모두 수신했습니다.`);
-    
-    // 5개의 결과에 대해 UI 업데이트
+
     apiResults.forEach((result, index) => {
       const originalComment = chunk[index];
       if (originalComment.loadingElement) originalComment.loadingElement.remove();
@@ -163,97 +112,91 @@ async processBatches() {
         purifiedContainer.innerHTML = `<span style="font-size: 12px; color: #6694FF;">[순화된 댓글입니다]</span><br>${result.purified_text}`;
 
         const hostname = window.location.hostname;
-        // 웹 페이지별 버튼 추가
         if (hostname.includes('youtube.com') || hostname.includes('naver.com')) {
-            purifiedContainer.style.fontSize = '14px';
-            this.createToggleSwitch(originalComment, purifiedContainer, hostname);
-          } else if (hostname.includes('instagram.com')) {
-            // 인스타그램 버튼 호출
-            this.createInstagramToggleButton(textElement, purifiedContainer);
-          }
-          
-          // 완성된 결과물을 화면에 딱 한 번만 삽입합니다.
-          textElement.parentNode.insertBefore(purifiedContainer, textElement);
-
-        } else {
-          textElement.style.setProperty('display', 'inline', 'important');
+          purifiedContainer.style.fontSize = '14px';
+          this.createToggleSwitch(originalComment, purifiedContainer, hostname);
+        } else if (hostname.includes('instagram.com')) {
+          this.createInstagramToggleButton(textElement, purifiedContainer);
         }
-      });
 
-    this.isProcessing = false;
-      if (this.commentQueue.length > 0) this.startBatchProcessing();
-    }
-
-// 유튜브/네이버 뉴스 토글 스위치 생성
-createToggleSwitch(originalComment, purifiedContainer, hostname) {
-  const textElement = originalComment.textElement;
-
-  const actionsContainer = hostname.includes('youtube.com')
-    ? originalComment.element.querySelector('#toolbar')
-    : originalComment.element.querySelector('.u_cbox_tool');
-
-  if (actionsContainer && !actionsContainer.querySelector('.toggle-switch')) {
-    const switchDiv = document.createElement('div');
-    switchDiv.className = 'toggle-switch active';
-
-    const label = document.createElement('span');
-    label.className = 'toggle-label-inside';
-    label.textContent = '순화';
-    
-    const circle = document.createElement('span');
-    circle.className = 'toggle-circle';
-
-    switchDiv.appendChild(label);
-    switchDiv.appendChild(circle);
-    
-    let isPurified = true;
-    switchDiv.onclick = (e) => {
-      e.preventDefault();  // 링크의 기본 동작(페이지 이동) 제어
-      e.stopPropagation(); // 이벤트 버블링 방지
-      isPurified = !isPurified;
-      switchDiv.classList.toggle('active', isPurified);
-      label.textContent = isPurified ? '순화' : '원본';
-      purifiedContainer.style.display = isPurified ? '' : 'none';
-      
-      if (isPurified) {
-        textElement.style.setProperty('display', 'none', 'important');
+        textElement.parentNode.insertBefore(purifiedContainer, textElement);
       } else {
         textElement.style.setProperty('display', 'inline', 'important');
       }
-    };
+    });
 
-    if (hostname.includes('naver.com')) {
-      const replyCountSpan = actionsContainer.querySelector('.u_cbox_reply_cnt');
+    this.isProcessing = false;
+    if (this.commentQueue.length > 0) this.startBatchProcessing();
+  }
 
-      if (replyCountSpan) {
-        replyCountSpan.parentNode.insertBefore(switchDiv, replyCountSpan.nextSibling);
+  createToggleSwitch(originalComment, purifiedContainer, hostname) {
+    const textElement = originalComment.textElement;
+
+    const actionsContainer = hostname.includes('youtube.com')
+      ? originalComment.element.querySelector('#toolbar')
+      : originalComment.element.querySelector('.u_cbox_tool');
+
+    if (actionsContainer && !actionsContainer.querySelector('.toggle-switch')) {
+      const switchDiv = document.createElement('div');
+      switchDiv.className = 'toggle-switch active';
+
+      const label = document.createElement('span');
+      label.className = 'toggle-label-inside';
+      label.textContent = '순화';
+
+      const circle = document.createElement('span');
+      circle.className = 'toggle-circle';
+
+      switchDiv.appendChild(label);
+      switchDiv.appendChild(circle);
+
+      let isPurified = true;
+      switchDiv.onclick = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        isPurified = !isPurified;
+        switchDiv.classList.toggle('active', isPurified);
+        label.textContent = isPurified ? '순화' : '원본';
+        purifiedContainer.style.display = isPurified ? '' : 'none';
+
+        if (isPurified) {
+          textElement.style.setProperty('display', 'none', 'important');
+        } else {
+          textElement.style.setProperty('display', 'inline', 'important');
+        }
+      };
+
+      if (hostname.includes('naver.com')) {
+        const replyCountSpan = actionsContainer.querySelector('.u_cbox_reply_cnt');
+
+        if (replyCountSpan) {
+          replyCountSpan.parentNode.insertBefore(switchDiv, replyCountSpan.nextSibling);
+        } else {
+          actionsContainer.appendChild(switchDiv);
+        }
       } else {
-        actionsContainer.appendChild(switchDiv);
-      }
-    } else { // 유튜브
-      const replyButton = actionsContainer.querySelector('yt-button-shape a');
-      if (replyButton) {
-        replyButton.parentNode.insertBefore(switchDiv, replyButton);
-      } else {
-        actionsContainer.appendChild(switchDiv);
+        const replyButton = actionsContainer.querySelector('yt-button-shape a');
+        if (replyButton) {
+          replyButton.parentNode.insertBefore(switchDiv, replyButton);
+        } else {
+          actionsContainer.appendChild(switchDiv);
+        }
       }
     }
   }
-}
 
-// 인스타그램 버튼 생성
-createInstagramToggleButton(textElement, purifiedContainer) {
-  const actionsSpan = textElement.closest('._a9zr')?.querySelector('span[class*="x1lliihq"]');
+  createInstagramToggleButton(textElement, purifiedContainer) {
+    const actionsSpan = textElement.closest('._a9zr')?.querySelector('span[class*="x1lliihq"]');
 
-  if (actionsSpan && !actionsSpan.querySelector('.know-comment-ai-toggle-btn')) {
-    const toggleButton = document.createElement('button');
-    toggleButton.textContent = '원본';
-    toggleButton.className = 'know-comment-ai-toggle-btn';
-    Object.assign(toggleButton.style, {
-      border: 'none', background: 'none', color: '#A8A8A8',
-      fontSize: '12px', fontWeight: 'bold', fontFamily: 'inherit', cursor: 'pointer', padding: '0',
-      marginLeft: '3px', marginRight: '3px', lineHeight: 'inherit'
-    });
+    if (actionsSpan && !actionsSpan.querySelector('.know-comment-ai-toggle-btn')) {
+      const toggleButton = document.createElement('button');
+      toggleButton.textContent = '원본';
+      toggleButton.className = 'know-comment-ai-toggle-btn';
+      Object.assign(toggleButton.style, {
+        border: 'none', background: 'none', color: '#A8A8A8',
+        fontSize: '12px', fontWeight: 'bold', fontFamily: 'inherit', cursor: 'pointer', padding: '0',
+        marginLeft: '3px', marginRight: '3px', lineHeight: 'inherit'
+      });
 
       let isPurified = true;
       toggleButton.onclick = () => {
@@ -263,12 +206,11 @@ createInstagramToggleButton(textElement, purifiedContainer) {
 
         if (isPurified) {
           textElement.style.setProperty('display', 'none', 'important');
-        } else { 
+        } else {
           textElement.style.setProperty('display', 'inline', 'important');
         }
       };
-      
-      // 위치 조정을 위해 답글 달기 버튼 찾기
+
       let replyButton = null;
       const allButtons = actionsSpan.querySelectorAll('button, div[role="button"]');
       for (const btn of allButtons) {
@@ -284,7 +226,6 @@ createInstagramToggleButton(textElement, purifiedContainer) {
         actionsSpan.appendChild(toggleButton);
       }
 
-      // 더보기 버튼을 원본 버튼 뒤에 삽입 
       const moreButtonDiv = actionsSpan.querySelector('div._a9ze');
       if (moreButtonDiv) {
         moreButtonDiv.style.marginLeft = 'auto';

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,77 +1,80 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
-import { resolve } from 'path'
-import fs from 'fs';
+import { resolve, dirname } from 'path'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
 
-export default defineConfig({
-  plugins: [
-    react(),
-    updateManifestHostPermissions(), //플러그인 추가
-  ],
-  build: {
-    rollupOptions: {
-      input: {
-        popup: resolve(__dirname, 'public/popup.html'),
-        content: resolve(__dirname, 'src/content/content.js'),
-        background: resolve(__dirname, 'src/background/background.js')
-      },
-      output: {
-        entryFileNames: (chunkInfo) => {
-          // content.js와 background.js는 dist 폴더 최상위에 생성
-          if (chunkInfo.name === 'content' || chunkInfo.name === 'background') {
-            return '[name].js';
-          }
-          // popup.html과 연결된 스크립트 등은 assets 폴더에 생성
-          return 'assets/[name].js';
+// ESM 환경에서 __dirname 대체
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const baseUrl = env.VITE_API_BASEURL
+
+  return {
+    plugins: [
+      react(),
+      updateManifestHostPermissions(baseUrl),
+    ],
+    build: {
+      rollupOptions: {
+        input: {
+          popup: resolve(__dirname, 'public/popup.html'),
+          content: resolve(__dirname, 'src/content/content.js'),
+          background: resolve(__dirname, 'src/background/background.js'),
+          'content-style': resolve(__dirname, 'src/content/content.css'),
         },
-        chunkFileNames: 'assets/[name].js',
-        assetFileNames: 'assets/[name].[ext]',
-      }
+        output: {
+          entryFileNames: (chunkInfo) => {
+            if (chunkInfo.name === 'content' || chunkInfo.name === 'background') {
+              return '[name].js'
+            }
+            return 'assets/[name].js'
+          },
+          chunkFileNames: 'assets/[name].js',
+          assetFileNames: (assetInfo) => {
+            const names = assetInfo.names || []
+            if (names.some(name => name.endsWith('content-style.css'))) {
+              return 'content.css'
+            }
+            return 'assets/[name].[ext]'
+          },
+        },
+      },
+      outDir: 'dist',
+      emptyOutDir: true,
+      copyPublicDir: true, // public 폴더 자동 복사
     },
-    outDir: 'dist',
-    emptyOutDir: true,
   }
 })
 
-// 빌드 후 manifest.json을 수정하는 커스텀 플러그인
-function updateManifestHostPermissions() {
+function updateManifestHostPermissions(baseUrl) {
   return {
     name: 'update-manifest-host-permissions',
-    // writeBundle + 모든 파일이 dist 폴더 생성 후 실행
     writeBundle: (options) => {
-      // .env 파일에서 VITE_API_BASEURL 값 호출
-      const env = loadEnv('', process.cwd(), '');
-      const baseUrl = env.VITE_API_BASEURL;
-
-      if (!baseUrl) {
-        console.warn('VITE_API_BASEURL이 .env 파일에 없습니다. manifest.json 수정이 건너뛰어집니다.');
-        return;
-      }
-
-      // 빌드된 manifest.json 파일 경로
-      const manifestPath = resolve(options.dir, 'manifest.json');
-
       try {
-        // manifest.json 파일 JSON 객체로 변환
-        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+        const manifestPath = resolve(options.dir, 'manifest.json')
 
-        if (!manifest.host_permissions) {
-          manifest.host_permissions = [];
+        if (!fs.existsSync(manifestPath)) {
+          console.warn('⚠️ dist/manifest.json이 존재하지 않습니다. public 폴더가 복사되지 않았을 수 있습니다.')
+          return
         }
 
-        // API 주소 host_permissions에 추가
-        const newPermission = `${baseUrl}/*`;
-        if (!manifest.host_permissions.includes(newPermission)) {
-            manifest.host_permissions.push(newPermission);
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
+        manifest.host_permissions = manifest.host_permissions || []
+
+        if (baseUrl) {
+          const newPermission = `${baseUrl}/*`
+          if (!manifest.host_permissions.includes(newPermission)) {
+            manifest.host_permissions.push(newPermission)
+          }
         }
 
-        // 수정된 manifest 객체 사용
-        fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
-        console.log('✅ manifest.json에 host_permissions이 성공적으로 추가되었습니다.');
-
-      } catch (e) {
-        console.error('manifest.json 수정 중 오류 발생:', e);
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
+        console.log('✅ manifest.json에 host_permissions이 성공적으로 추가되었습니다.')
+      } catch (err) {
+        console.error('❌ manifest.json 수정 중 오류 발생:', err)
       }
     },
-  };
+  }
 }


### PR DESCRIPTION
- [x] content.js의 스타일 관련 코드 분리 (content.css로)
- [x] 다크모드 시 스타일 지정
- [x] manifest, config에 css 추가

<img width="506" height="471" alt="image" src="https://github.com/user-attachments/assets/e285f830-7942-4d0d-a27c-b96eff64adeb" />
<- 유튜브 라이트모드
<img width="606" height="372" alt="스크린샷 2025-10-12 134014" src="https://github.com/user-attachments/assets/a8295991-b25d-43a0-aa6e-ce20965caffb" />
<- 유튜브 다크모드


<img width="429" height="253" alt="스크린샷 2025-10-12 133952" src="https://github.com/user-attachments/assets/7b41523b-3a29-41b0-9a77-26f789dc4c4e" />
<- 인스타 (라이트모드와 스타일 동일) 


*네이버는 라이트 모드 X

